### PR TITLE
Merge menu item options database tables

### DIFF
--- a/Extension.php
+++ b/Extension.php
@@ -133,16 +133,6 @@ class Extension extends BaseExtension
                     'destroy:admin',
                 ],
             ],
-            'menu_item_options' => [
-                'controller' => \Igniter\Api\ApiResources\MenuItemOptions::class,
-                'name' => 'MenuItemOptions',
-                'description' => 'An API resource for Menu item options',
-                'actions' => [
-                    'index:admin', 'show:admin',
-                    'store:admin', 'update:admin',
-                    'destroy:admin',
-                ],
-            ],
             'orders' => [
                 'controller' => \Igniter\Api\ApiResources\Orders::class,
                 'name' => 'Orders',

--- a/apiresources/MenuItemOptions.php
+++ b/apiresources/MenuItemOptions.php
@@ -6,6 +6,8 @@ use Igniter\Api\Classes\ApiController;
 
 /**
  * Options API Controller
+ *
+ * @deprecated remove before v4. Added for backward compatibility
  */
 class MenuItemOptions extends ApiController
 {

--- a/apiresources/repositories/MenuItemOptionRepository.php
+++ b/apiresources/repositories/MenuItemOptionRepository.php
@@ -5,6 +5,9 @@ namespace Igniter\Api\ApiResources\Repositories;
 use Admin\Models\Menu_item_options_model;
 use Igniter\Api\Classes\AbstractRepository;
 
+/**
+ * @deprecated remove before v4. Added for backward compatibility
+ */
 class MenuItemOptionRepository extends AbstractRepository
 {
     protected $modelClass = Menu_item_options_model::class;

--- a/apiresources/requests/MenuItemOptionRequest.php
+++ b/apiresources/requests/MenuItemOptionRequest.php
@@ -4,6 +4,9 @@ namespace Igniter\Api\ApiResources\Requests;
 
 use System\Classes\FormRequest;
 
+/**
+ * @deprecated remove before v4. Added for backward compatibility
+ */
 class MenuItemOptionRequest extends FormRequest
 {
     public function rules()

--- a/apiresources/transformers/MenuItemOptionTransformer.php
+++ b/apiresources/transformers/MenuItemOptionTransformer.php
@@ -5,6 +5,9 @@ namespace Igniter\Api\ApiResources\Transformers;
 use Admin\Models\Menu_item_options_model;
 use League\Fractal\TransformerAbstract;
 
+/**
+ * @deprecated remove before v4. Added for backward compatibility
+ */
 class MenuItemOptionTransformer extends TransformerAbstract
 {
     protected $defaultIncludes = [
@@ -22,7 +25,7 @@ class MenuItemOptionTransformer extends TransformerAbstract
     public function includeMenuOptionValues(Menu_item_options_model $menuItemOption)
     {
         //When Post/Patch and inside body comes with an json array menu_option_values the deserialized object is a collection of array
-        if (is_array($menuItemOption->menu_option_values)){
+        if (is_array($menuItemOption->menu_option_values)) {
             return $this->collection(
                 $menuItemOption->menu_option_values,
                 new MenuItemOptionValueArrayTransformer,


### PR DESCRIPTION
Related https://github.com/tastyigniter/TastyIgniter/pull/901


- Deprecates menu item options endpoint, use the menus endpoint to managing menu item options